### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/SOAP/Client.pm6
+++ b/lib/SOAP/Client.pm6
@@ -1,4 +1,4 @@
-class SOAP::Client;
+unit class SOAP::Client;
 
 use SOAP::Client::WSDL;
 use LWP::Simple;

--- a/lib/SOAP/Client/WSDL.pm6
+++ b/lib/SOAP/Client/WSDL.pm6
@@ -1,4 +1,4 @@
-class SOAP::Client::WSDL;
+unit class SOAP::Client::WSDL;
 
 use LWP::Simple;
 use XML;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
